### PR TITLE
on iOS: Creating own virtual devices is now supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.3
+- Improved bluetooth state handling:
+  - Start bluetooth subsystem only when you want, not automatically
+  - Allow to retrieve bluetooth state before starting scanning
+  - Allow to observe bluetooth state (poweredOn, poweredOff, ...)
+
 ## 0.3.2
 - Fixed null warning
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Import flutter_midi_command
 - Listen for incoming MIDI messages on from the current device by subscribing to `MidiCommand().onMidiDataReceived`, after which the listener will recieve inbound MIDI messages as an UInt8List of variable length.
 - Send a MIDI message by calling `MidiCommand.sendData(data)`, where data is an UInt8List of bytes following the MIDI spec.
 - Or use the various `MidiCommand` subtypes to send PC, CC, NoteOn and NoteOff messsages.
+- On iOS use `MidiCommand().addVirtualDevice(name: "Your Device Name")` to create a virtual MIDI destination and a virtual MIDI source. These virtual MIDI devices show up in other apps and can be used by other apps to send and receive MIDI to or from your app. To make this feature work, enable background audio for your app, i.e., add key `UIBackgroundModes` with value `audio` to your app's `info.plist` file.
 
 See example folder for how to use.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Import flutter_midi_command
 `import 'package:flutter_midi_command/flutter_midi_command.dart';`
 
 - Get a list of available MIDI devices by calling `MidiCommand().devices` which returns a list of `MidiDevice`
+- Start bluetooth subsystem by calling `MidiCommand().startBluetoothCentral()`
 - Start scanning for BLE MIDI devices by calling `MidiCommand().startScanningForBluetoothDevices()`
 - Connect to a specific `MidiDevice` by calling `MidiCommand.connectToDevice(selectedDevice)`
 - Stop scanning for BLE MIDI devices by calling `MidiCommand().stopScanningForBluetoothDevices()`

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Import flutter_midi_command
 - Get a list of available MIDI devices by calling `MidiCommand().devices` which returns a list of `MidiDevice`
 - Start bluetooth subsystem by calling `MidiCommand().startBluetoothCentral()`
 - Observe the bluetooth system state by calling `MidiCommand().onBluetoothStateChanged()`
+- Get the current bluetooth system state by calling `MidiCommand().bluetoothState()`
 - Start scanning for BLE MIDI devices by calling `MidiCommand().startScanningForBluetoothDevices()`
 - Connect to a specific `MidiDevice` by calling `MidiCommand.connectToDevice(selectedDevice)`
 - Stop scanning for BLE MIDI devices by calling `MidiCommand().stopScanningForBluetoothDevices()`

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Import flutter_midi_command
 
 - Get a list of available MIDI devices by calling `MidiCommand().devices` which returns a list of `MidiDevice`
 - Start bluetooth subsystem by calling `MidiCommand().startBluetoothCentral()`
+- Observe the bluetooth system state by calling `MidiCommand().onBluetoothStateChanged()`
 - Start scanning for BLE MIDI devices by calling `MidiCommand().startScanningForBluetoothDevices()`
 - Connect to a specific `MidiDevice` by calling `MidiCommand.connectToDevice(selectedDevice)`
 - Stop scanning for BLE MIDI devices by calling `MidiCommand().stopScanningForBluetoothDevices()`

--- a/lib/flutter_midi_command_platform_interface.dart
+++ b/lib/flutter_midi_command_platform_interface.dart
@@ -79,6 +79,7 @@ abstract class MidiCommandPlatform extends PlatformInterface {
   /// For example, when a new BLE devices is discovered.
   Stream<String>? get onMidiSetupChanged {
     throw UnimplementedError('get onMidiSetupChanged has not been implemented.');
+  }
 
   /// Creates a virtual MIDI source.
   void addVirtualDevice({String? name}) {

--- a/lib/flutter_midi_command_platform_interface.dart
+++ b/lib/flutter_midi_command_platform_interface.dart
@@ -43,6 +43,12 @@ abstract class MidiCommandPlatform extends PlatformInterface {
         'startBluetoothCentral() has not been implemented.');
   }
 
+  /// Stream firing events whenever the bluetooth central state changes
+  Stream<String>? get onBluetoothStateChanged {
+    throw UnimplementedError(
+        'get onBluetoothStateChanged has not been implemented.');
+  }
+
   /// Starts scanning for BLE MIDI devices.
   ///
   /// Found devices will be included in the list returned by [devices].

--- a/lib/flutter_midi_command_platform_interface.dart
+++ b/lib/flutter_midi_command_platform_interface.dart
@@ -36,6 +36,13 @@ abstract class MidiCommandPlatform extends PlatformInterface {
     throw UnimplementedError('get devices has not been implemented.');
   }
 
+  /// Starts bluetooth subsystem. Shows an alert requesting access rights for
+  /// bluetooth.
+  Future<void> startBluetoothCentral() async {
+    throw UnimplementedError(
+        'startBluetoothCentral() has not been implemented.');
+  }
+
   /// Starts scanning for BLE MIDI devices.
   ///
   /// Found devices will be included in the list returned by [devices].

--- a/lib/flutter_midi_command_platform_interface.dart
+++ b/lib/flutter_midi_command_platform_interface.dart
@@ -79,5 +79,14 @@ abstract class MidiCommandPlatform extends PlatformInterface {
   /// For example, when a new BLE devices is discovered.
   Stream<String>? get onMidiSetupChanged {
     throw UnimplementedError('get onMidiSetupChanged has not been implemented.');
+
+  /// Creates a virtual MIDI source.
+  void addVirtualDevice({String? name}) {
+    throw UnimplementedError('addVirtualDevice() has not been implemented.');
+  }
+
+  /// Removes a previously created virtual MIDI source.
+  void removeVirtualDevice({String? name}) {
+    throw UnimplementedError('removeVirtualDevice() has not been implemented.');
   }
 }

--- a/lib/flutter_midi_command_platform_interface.dart
+++ b/lib/flutter_midi_command_platform_interface.dart
@@ -49,16 +49,23 @@ abstract class MidiCommandPlatform extends PlatformInterface {
         'get onBluetoothStateChanged has not been implemented.');
   }
 
+  /// Returns the current state of the bluetooth sub system
+  Future<String> bluetoothState() async {
+    throw UnimplementedError('bluetoothState() has not been implemented.');
+  }
+
   /// Starts scanning for BLE MIDI devices.
   ///
   /// Found devices will be included in the list returned by [devices].
   Future<void> startScanningForBluetoothDevices() async {
-    throw UnimplementedError('startScanningForBluetoothDevices() has not been implemented.');
+    throw UnimplementedError(
+        'startScanningForBluetoothDevices() has not been implemented.');
   }
 
   /// Stops scanning for BLE MIDI devices.
   void stopScanningForBluetoothDevices() {
-    throw UnimplementedError('stopScanningForBluetoothDevices() has not been implemented.');
+    throw UnimplementedError(
+        'stopScanningForBluetoothDevices() has not been implemented.');
   }
 
   /// Connects to the device.
@@ -84,14 +91,16 @@ abstract class MidiCommandPlatform extends PlatformInterface {
   }
 
   Stream<MidiPacket>? get onMidiDataReceived {
-    throw UnimplementedError('get onMidiDataReceived has not been implemented.');
+    throw UnimplementedError(
+        'get onMidiDataReceived has not been implemented.');
   }
 
   /// Stream firing events whenever a change in the MIDI setup occurs.
   ///
   /// For example, when a new BLE devices is discovered.
   Stream<String>? get onMidiSetupChanged {
-    throw UnimplementedError('get onMidiSetupChanged has not been implemented.');
+    throw UnimplementedError(
+        'get onMidiSetupChanged has not been implemented.');
   }
 
   /// Creates a virtual MIDI source.

--- a/lib/method_channel_midi_command.dart
+++ b/lib/method_channel_midi_command.dart
@@ -105,4 +105,19 @@ class MethodChannelMidiCommand extends MidiCommandPlatform {
     _setupStream ??= _setupChannel.receiveBroadcastStream().cast<String>();
     return _setupStream;
   }
+
+  /// Creates a virtual MIDI source
+  ///
+  /// The virtual MIDI source appears as a virtual port in other apps.
+  /// Currently only supported on iOS.
+  @override
+  void addVirtualDevice({String? name}) {
+    _methodChannel.invokeMethod('addVirtualDevice', {"name": name});
+  }
+
+  /// Removes a previously addd virtual MIDI source.
+  @override
+  void removeVirtualDevice({String? name}) {
+    _methodChannel.invokeMethod('removeVirtualDevice', {"name": name});
+  }
 }

--- a/lib/method_channel_midi_command.dart
+++ b/lib/method_channel_midi_command.dart
@@ -89,8 +89,10 @@ class MethodChannelMidiCommand extends MidiCommandPlatform {
     _rxStream ??= _rxChannel.receiveBroadcastStream().map<MidiPacket>((d) {
       var dd = d["device"];
       // print("device data $dd");
-      var device = MidiDevice(dd['id'], dd["name"], dd["type"], dd["connected"]);
-      return MidiPacket(Uint8List.fromList(List<int>.from(d["data"])), d["timestamp"] as int, device);
+      var device = MidiDevice(
+          dd['id'], dd["name"], dd["type"], dd["connected"] == "true");
+      return MidiPacket(Uint8List.fromList(List<int>.from(d["data"])),
+          d["timestamp"] as int, device);
     });
     return _rxStream;
   }

--- a/lib/method_channel_midi_command.dart
+++ b/lib/method_channel_midi_command.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:typed_data';
 import 'package:flutter/services.dart';
-import 'package:flutter_midi_command_platform_interface/midi_device.dart';
 import 'flutter_midi_command_platform_interface.dart';
 
 const MethodChannel _methodChannel = MethodChannel('plugins.invisiblewrench.com/flutter_midi_command');
@@ -35,6 +34,17 @@ class MethodChannelMidiCommand extends MidiCommandPlatform {
     return ports.toList(growable: false);
   }
 
+  /// Starts bluetooth subsystem.
+  ///
+  /// Shows an alert requesting access rights for bluetooth.
+  @override
+  Future<void> startBluetoothCentral() async {
+    try {
+      await _methodChannel.invokeMethod('startBluetoothCentral');
+    } on PlatformException catch (e) {
+      throw e.message!;
+    }
+  }
   /// Starts scanning for BLE MIDI devices.
   ///
   /// Found devices will be included in the list returned by [devices].

--- a/lib/method_channel_midi_command.dart
+++ b/lib/method_channel_midi_command.dart
@@ -3,9 +3,12 @@ import 'dart:typed_data';
 import 'package:flutter/services.dart';
 import 'flutter_midi_command_platform_interface.dart';
 
-const MethodChannel _methodChannel = MethodChannel('plugins.invisiblewrench.com/flutter_midi_command');
-const EventChannel _rxChannel = EventChannel('plugins.invisiblewrench.com/flutter_midi_command/rx_channel');
-const EventChannel _setupChannel = EventChannel('plugins.invisiblewrench.com/flutter_midi_command/setup_channel');
+const MethodChannel _methodChannel =
+    MethodChannel('plugins.invisiblewrench.com/flutter_midi_command');
+const EventChannel _rxChannel =
+    EventChannel('plugins.invisiblewrench.com/flutter_midi_command/rx_channel');
+const EventChannel _setupChannel = EventChannel(
+    'plugins.invisiblewrench.com/flutter_midi_command/setup_channel');
 const EventChannel _bluetoothStateChannel = EventChannel(
     'plugins.invisiblewrench.com/flutter_midi_command/bluetooth_central_state');
 
@@ -21,7 +24,8 @@ class MethodChannelMidiCommand extends MidiCommandPlatform {
     var devs = await _methodChannel.invokeMethod('getDevices');
     return devs.map<MidiDevice>((m) {
       var map = m.cast<String, Object>();
-      var dev = MidiDevice(map["id"].toString(), map["name"], map["type"], map["connected"] == "true");
+      var dev = MidiDevice(map["id"].toString(), map["name"], map["type"],
+          map["connected"] == "true");
       dev.inputPorts = _portsFromDevice(map["inputs"], MidiPortType.IN);
       dev.outputPorts = _portsFromDevice(map["outputs"], MidiPortType.OUT);
       return dev;
@@ -57,6 +61,16 @@ class MethodChannelMidiCommand extends MidiCommandPlatform {
     return _bluetoothStateStream;
   }
 
+  /// Returns the current state of the bluetooth subsystem
+  @override
+  Future<String> bluetoothState() async {
+    try {
+      return await _methodChannel.invokeMethod('bluetoothState');
+    } on PlatformException catch (e) {
+      throw e.message!;
+    }
+  }
+
   /// Starts scanning for BLE MIDI devices.
   ///
   /// Found devices will be included in the list returned by [devices].
@@ -78,7 +92,8 @@ class MethodChannelMidiCommand extends MidiCommandPlatform {
   /// Connects to the device.
   @override
   void connectToDevice(MidiDevice device, {List<MidiPort>? ports}) {
-    _methodChannel.invokeMethod('connectToDevice', {"device": device.toDictionary, "ports": ports});
+    _methodChannel.invokeMethod(
+        'connectToDevice', {"device": device.toDictionary, "ports": ports});
   }
 
   /// Disconnects from the device.
@@ -99,7 +114,8 @@ class MethodChannelMidiCommand extends MidiCommandPlatform {
   @override
   void sendData(Uint8List data, {int? timestamp, String? deviceId}) {
     // print("send $data through method channel");
-    _methodChannel.invokeMethod('sendData', {"data": data, "timestamp": timestamp, "deviceId": deviceId});
+    _methodChannel.invokeMethod('sendData',
+        {"data": data, "timestamp": timestamp, "deviceId": deviceId});
   }
 
   /// Stream firing events whenever a midi package is received.

--- a/lib/method_channel_midi_command.dart
+++ b/lib/method_channel_midi_command.dart
@@ -6,11 +6,14 @@ import 'flutter_midi_command_platform_interface.dart';
 const MethodChannel _methodChannel = MethodChannel('plugins.invisiblewrench.com/flutter_midi_command');
 const EventChannel _rxChannel = EventChannel('plugins.invisiblewrench.com/flutter_midi_command/rx_channel');
 const EventChannel _setupChannel = EventChannel('plugins.invisiblewrench.com/flutter_midi_command/setup_channel');
+const EventChannel _bluetoothStateChannel = EventChannel(
+    'plugins.invisiblewrench.com/flutter_midi_command/bluetooth_central_state');
 
 /// An implementation of [MidiCommandPlatform] that uses method channels.
 class MethodChannelMidiCommand extends MidiCommandPlatform {
   Stream<MidiPacket>? _rxStream;
   Stream<String>? _setupStream;
+  Stream<String>? _bluetoothStateStream;
 
   /// Returns a list of found MIDI devices.
   @override
@@ -45,6 +48,15 @@ class MethodChannelMidiCommand extends MidiCommandPlatform {
       throw e.message!;
     }
   }
+
+  /// Stream firing events whenever a change in bluetooth central state happens
+  @override
+  Stream<String>? get onBluetoothStateChanged {
+    _bluetoothStateStream ??=
+        _bluetoothStateChannel.receiveBroadcastStream().cast<String>();
+    return _bluetoothStateStream;
+  }
+
   /// Starts scanning for BLE MIDI devices.
   ///
   /// Found devices will be included in the list returned by [devices].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command_platform_interface
 description: A common platform interface for the FlutterMidiCommand plugin.
-version: 0.3.2
+version: 0.3.3
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 
 environment:


### PR DESCRIPTION
This pull request accompanies another pull request for FlutterMidiCommand. 
It makes it possible to create virtual MIDI Devices that show up in other apps. 
Other apps can then send and receive MIDI to or from your own app.