### PR TITLE
Added flag to receive the raw MIDI packets without preprocessing

### DIFF
--- a/lib/flutter_midi_command_platform_interface.dart
+++ b/lib/flutter_midi_command_platform_interface.dart
@@ -124,13 +124,13 @@ abstract class MidiCommandPlatform extends PlatformInterface {
     throw UnimplementedError(
         'setNetworkSessionEnabled has not been implemented.');
 
-  /// Returns the current state of the raw midi receiving flag.
+  /// Returns the current state of the raw MIDI receiving flag.
   Future<bool?> getRawMidiDataReceivingEnabled(String deviceId) {
     throw UnimplementedError('getRawMidiDataReceivingEnabled has not been implemented.');
   }
 
   /// When enabled all incoming MIDI packets are transmitted exactly as received,
-  /// without compiling them into well formed midi messages.
+  /// without compiling them into well formed MIDI messages.
   Future<void> setRawMidiDataReceivingEnabled(String deviceId, bool enabled) {
     throw UnimplementedError('setRawMidiDataReceivingEnabled has not been implemented.');
   }

--- a/lib/flutter_midi_command_platform_interface.dart
+++ b/lib/flutter_midi_command_platform_interface.dart
@@ -123,5 +123,15 @@ abstract class MidiCommandPlatform extends PlatformInterface {
   void setNetworkSessionEnabled(bool enabled) {
     throw UnimplementedError(
         'setNetworkSessionEnabled has not been implemented.');
+
+  /// Returns the current state of the raw midi receiving flag.
+  Future<bool?> getRawMidiDataReceivingEnabled(String deviceId) {
+    throw UnimplementedError('getRawMidiDataReceivingEnabled has not been implemented.');
+  }
+
+  /// When enabled all incoming MIDI packets are transmitted exactly as received,
+  /// without compiling them into well formed midi messages.
+  Future<void> setRawMidiDataReceivingEnabled(String deviceId, bool enabled) {
+    throw UnimplementedError('setRawMidiDataReceivingEnabled has not been implemented.');
   }
 }

--- a/lib/flutter_midi_command_platform_interface.dart
+++ b/lib/flutter_midi_command_platform_interface.dart
@@ -123,6 +123,7 @@ abstract class MidiCommandPlatform extends PlatformInterface {
   void setNetworkSessionEnabled(bool enabled) {
     throw UnimplementedError(
         'setNetworkSessionEnabled has not been implemented.');
+  }
 
   /// Returns the current state of the raw MIDI receiving flag.
   Future<bool?> getRawMidiDataReceivingEnabled(String deviceId) {

--- a/lib/method_channel_midi_command.dart
+++ b/lib/method_channel_midi_command.dart
@@ -35,7 +35,7 @@ class MethodChannelMidiCommand extends MidiCommandPlatform {
     if (portList == null) return [];
     var ports = portList.map<MidiPort>((e) {
       var portMap = (e as Map).cast<String, Object>();
-      return MidiPort(portMap["id"] as int, type);
+      return MidiPort(portMap["id"] as int, type, portMap['name'] as String);
     });
     return ports.toList(growable: false);
   }

--- a/lib/method_channel_midi_command.dart
+++ b/lib/method_channel_midi_command.dart
@@ -171,4 +171,17 @@ class MethodChannelMidiCommand extends MidiCommandPlatform {
   void setNetworkSessionEnabled(bool enabled) {
     _methodChannel.invokeMethod('enableNetworkSession', enabled);
   }
+
+  /// Returns the current state of the raw MIDI message receiving flag.
+  Future<bool?> getRawMidiDataReceivingEnabled(String deviceId) {
+    return _methodChannel.invokeMethod('isRawMidiDataReceivingEnabled', {'deviceId': deviceId});
+  }
+
+  /// Sets the enabled state of raw MIDI data recieving.
+  Future<void> setRawMidiDataReceivingEnabled(String deviceId, bool enabled) {
+    return _methodChannel.invokeMethod(
+      'enableRawMidiDataReceiving',
+      {'deviceId': deviceId, 'enabled': enabled},
+    );
+  }
 }

--- a/lib/midi_port.dart
+++ b/lib/midi_port.dart
@@ -4,10 +4,11 @@ class MidiPort {
   MidiPortType type;
   int id;
   bool connected = false;
+  String name;
 
-  MidiPort(this.id, this.type);
+  MidiPort(this.id, this.type, this.name);
 
   Map<String, Object> get toDictionary {
-    return {"id": id, "type": type.toString(), "connected": connected};
+    return {"id": id, "name": name, "type": type.toString(), "connected": connected};
   }
 }


### PR DESCRIPTION
Adds a flag to enable receiving the raw MIDI packet stream from the platform.
An example implementation for iOS is added here: https://github.com/InvisibleWrench/FlutterMidiCommand/pull/110