### PR TITLE
Check if device name is null and device type is virtual to set id as name

### DIFF
--- a/lib/method_channel_midi_command.dart
+++ b/lib/method_channel_midi_command.dart
@@ -126,7 +126,7 @@ class MethodChannelMidiCommand extends MidiCommandPlatform {
     _rxStream ??= _rxChannel.receiveBroadcastStream().map<MidiPacket>((d) {
       var dd = d["device"];
       // print("device data $dd");
-      if ((dd["type"] == 'virtual') && (dd["name"] == null)) {
+      if (dd["name"] == null) {
           dd["name"] = dd['id'];
       }
       var device = MidiDevice(

--- a/lib/method_channel_midi_command.dart
+++ b/lib/method_channel_midi_command.dart
@@ -126,6 +126,9 @@ class MethodChannelMidiCommand extends MidiCommandPlatform {
     _rxStream ??= _rxChannel.receiveBroadcastStream().map<MidiPacket>((d) {
       var dd = d["device"];
       // print("device data $dd");
+      if ((dd["type"] == 'virtual') && (dd["name"] == null)) {
+          dd["name"] = dd['id'];
+      }
       var device = MidiDevice(
           dd['id'], dd["name"], dd["type"], dd["connected"] == "true");
       return MidiPacket(Uint8List.fromList(List<int>.from(d["data"])),


### PR DESCRIPTION
This pull request addresses issue #3.
In addition to the fix described in the issue, I added a null check on device name to avoid overwriting it in case it is set (on Linux only).